### PR TITLE
Avoids mutating the provided query object.

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -110,4 +110,17 @@ describe('mongoose-cursor-pagination', function () {
         should.equal(results.items[4].value, 990)
       })
   })
+
+  it('does not modify the provided query object', function () {
+    const query = {}
+
+    return mongoose.model('User').paginate(query, {
+      key: 'value',
+      sort: { value: -1 },
+      endingBefore: 995
+    })
+      .then(() => {
+        query.should.eql({})
+      })
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export default function paginationPlugin (schema, pluginOptions) {
   }
 
   schema.statics.paginate = function (query, options, callback) {
-    query = query || {}
+    query = query ? { ...query } : {}
     options = options || {}
     options.limit = +options.limit || defaultOptions.limit
     options = { ...defaultOptions, ...options }


### PR DESCRIPTION
It is an unexpected side effect to modify mutate the provided query object. It's a very simple change, would really appreciate it if you merge this one.